### PR TITLE
Don't revert to Stars when editing a Scale widget

### DIFF
--- a/constellation_forms/static/constellation_forms/js/widgets/scale.hbs
+++ b/constellation_forms/static/constellation_forms/js/widgets/scale.hbs
@@ -1,9 +1,9 @@
 <form action="#" class="form-part mdl-grid" id="form-part-{{ id }}">
     <div class="mdl-cell mdl-cell--12-col drag-handle-holder drag-handle"><i class="material-icons drag-handle">drag_handle</i></div>
     <div class="mdl-cell--8-col widget-type mdl-cell--order-2-desktop mdl-cell--4-col-desktop">
-        <select class="multi-selector" name="type" value="{{ contents.type }}">
-            <option value="stars">Stars</option>
-            <option value="slider">Slider</option>
+        <select class="multi-selector" name="type">
+            <option value="stars"{{#if_eq contents.type "stars"}} selected{{/if_eq}}>Stars</option>
+            <option value="slider"{{#if_eq contents.type "slider"}} selected{{/if_eq}}>Slider</option>
         </select>
     </div>
     {{> widgetMeta name="Scale" type="scale" element=contents}}


### PR DESCRIPTION
Fixes #27 

Clear your cache, widget cache can be more finicky than a hard-refresh